### PR TITLE
Fix: expand tilde in --vault-key default

### DIFF
--- a/internal/cmd/remote.go
+++ b/internal/cmd/remote.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/kgatilin/myhome/internal/config"
+	"github.com/kgatilin/myhome/internal/pathutil"
 	"github.com/kgatilin/myhome/internal/remote"
 )
 
@@ -147,6 +148,7 @@ var remoteInitCmd = &cobra.Command{
 		}
 
 		vaultKey, _ := cmd.Flags().GetString("vault-key")
+		vaultKey = pathutil.ExpandTilde(vaultKey)
 
 		fmt.Printf("Bootstrapping %s (%s) with env %s...\n", hostName, remoteCfg.Host, remoteCfg.Env)
 

--- a/internal/pathutil/expand.go
+++ b/internal/pathutil/expand.go
@@ -1,0 +1,23 @@
+package pathutil
+
+import (
+	"os"
+	"strings"
+)
+
+// ExpandTilde replaces a leading ~ with the current user's home directory.
+// Returns the path unchanged if it doesn't start with ~ or if home dir lookup fails.
+func ExpandTilde(path string) string {
+	if path == "~" {
+		if home, err := os.UserHomeDir(); err == nil {
+			return home
+		}
+		return path
+	}
+	if strings.HasPrefix(path, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return home + path[1:]
+		}
+	}
+	return path
+}

--- a/internal/pathutil/expand_test.go
+++ b/internal/pathutil/expand_test.go
@@ -1,0 +1,34 @@
+package pathutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExpandTilde(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("cannot get home dir: %v", err)
+	}
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"~/.secrets/vault.key", filepath.Join(home, ".secrets/vault.key")},
+		{"~", home},
+		{"~/", home + "/"},
+		{"/absolute/path", "/absolute/path"},
+		{"relative/path", "relative/path"},
+		{"", ""},
+		{"~other", "~other"}, // not current user's home
+	}
+
+	for _, tt := range tests {
+		got := ExpandTilde(tt.input)
+		if got != tt.want {
+			t.Errorf("ExpandTilde(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- `--vault-key` defaults to `~/.secrets/vault.key` but `scp` does not expand `~`, causing a "No such file or directory" error
- Added `pathutil.ExpandTilde()` helper that resolves `~` to `os.UserHomeDir()`
- Applied expansion in `remote init` command before passing the path to scp

Fixes #24

## Test plan
- [ ] `go test ./internal/pathutil/` passes
- [ ] `myhome remote init <host>` with default `--vault-key` no longer fails on tilde