### PR TITLE
feat: add process-mode agents for sub-agent spawning inside containers

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -25,6 +25,14 @@ const (
 	StatusFailed   AgentStatus = "failed"
 )
 
+// AgentMode represents how an agent runs: in a container or as a local process.
+type AgentMode string
+
+const (
+	ModeContainer AgentMode = "container"
+	ModeProcess   AgentMode = "process"
+)
+
 // AgentRuntime holds runtime/session state for an agent.
 type AgentRuntime struct {
 	GRPCPort     int     `yaml:"grpc_port,omitempty"`
@@ -39,11 +47,13 @@ type AgentRuntime struct {
 // State holds the runtime state of an agent, persisted to disk.
 type State struct {
 	Name         string      `yaml:"name"`
+	Mode         AgentMode   `yaml:"mode,omitempty"`
 	ContainerID  string      `yaml:"container_id,omitempty"`
+	PID          int         `yaml:"pid,omitempty"`
 	SessionID    string      `yaml:"session_id,omitempty"`
 	Status       AgentStatus `yaml:"status"`
 	CreatedAt    time.Time   `yaml:"created_at"`
-	Container    string      `yaml:"container"` // container config name from myhome.yml
+	Container    string      `yaml:"container,omitempty"` // container config name from myhome.yml
 	AgentRuntime `yaml:",inline"`
 }
 
@@ -54,6 +64,7 @@ type ExecFunc func(name string, args ...string) *exec.Cmd
 type Manager struct {
 	store *Store
 	ctr   containerOps
+	proc  processOps
 	Vault vault.Reader // optional: for resolving SSH keys and vault:// secrets
 }
 
@@ -66,11 +77,39 @@ func NewManager(store *Store, execFn ExecFunc, runtime, homeDir string) *Manager
 			runtime: runtime,
 			homeDir: homeDir,
 		},
+		proc: processOps{
+			execFn:  execFn,
+			homeDir: homeDir,
+		},
 	}
 }
 
-// Create starts a new agent container from config and persists its state.
-func (m *Manager) Create(name string, agentCfg config.AgentConfig, cfg *config.Config) error {
+// CreateOpts holds options for agent creation that aren't part of config.
+type CreateOpts struct {
+	Mode    AgentMode
+	Prompt  string // initial prompt for process-mode agents
+	WorkDir string // override work dir (for process mode without mounts config)
+}
+
+// Create starts a new agent from config and persists its state.
+// For container mode, it starts a Docker container. For process mode, it spawns claude as a background process.
+func (m *Manager) Create(name string, agentCfg config.AgentConfig, cfg *config.Config, opts ...CreateOpts) error {
+	var opt CreateOpts
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+	if opt.Mode == "" {
+		opt.Mode = ModeContainer
+	}
+
+	if opt.Mode == ModeProcess {
+		return m.createProcess(name, agentCfg, opt)
+	}
+	return m.createContainer(name, agentCfg, cfg)
+}
+
+// createContainer starts a new agent in a Docker container.
+func (m *Manager) createContainer(name string, agentCfg config.AgentConfig, cfg *config.Config) error {
 	if existing, err := m.store.Load(name); err == nil {
 		if existing.Status == StatusRunning {
 			return fmt.Errorf("agent %q is already running", name)
@@ -110,6 +149,7 @@ func (m *Manager) Create(name string, agentCfg config.AgentConfig, cfg *config.C
 
 	state := &State{
 		Name:      name,
+		Mode:      ModeContainer,
 		Status:    StatusCreating,
 		CreatedAt: time.Now(),
 		Container: agentCfg.Container,
@@ -150,7 +190,65 @@ func (m *Manager) Create(name string, agentCfg config.AgentConfig, cfg *config.C
 	return nil
 }
 
-// Stop gracefully stops an agent's container.
+// createProcess starts a new agent as a local claude process.
+func (m *Manager) createProcess(name string, agentCfg config.AgentConfig, opt CreateOpts) error {
+	if existing, err := m.store.Load(name); err == nil {
+		if existing.Status == StatusRunning {
+			return fmt.Errorf("agent %q is already running", name)
+		}
+		m.store.Remove(name)
+	}
+
+	logFile := filepath.Join(m.store.LogDir(), name+".log")
+	workDir := opt.WorkDir
+	if workDir == "" && len(agentCfg.Mounts) > 0 {
+		// Use first mount's host path as work dir
+		m0 := strings.TrimSuffix(agentCfg.Mounts[0], ":ro")
+		parts := strings.SplitN(m0, ":", 2)
+		workDir = expandHome(parts[0], m.proc.homeDir)
+		if !filepath.IsAbs(workDir) {
+			workDir = filepath.Join(m.proc.homeDir, workDir)
+		}
+	}
+
+	prompt := opt.Prompt
+	if prompt == "" {
+		prompt = "You are agent " + name + ". Wait for instructions."
+	}
+
+	state := &State{
+		Name:      name,
+		Mode:      ModeProcess,
+		Status:    StatusCreating,
+		CreatedAt: time.Now(),
+		AgentRuntime: AgentRuntime{
+			LogFile:      logFile,
+			Model:        agentCfg.Model,
+			SystemPrompt: agentCfg.SystemPrompt,
+			WorkDir:      workDir,
+		},
+	}
+	if err := m.store.Save(state); err != nil {
+		return fmt.Errorf("saving initial state: %w", err)
+	}
+
+	pid, err := m.proc.startProcess(prompt, logFile, workDir, agentCfg.Model, agentCfg.SystemPrompt, agentCfg.Env)
+	if err != nil {
+		state.Status = StatusFailed
+		m.store.Save(state)
+		return fmt.Errorf("starting agent process: %w", err)
+	}
+
+	state.PID = pid
+	state.Status = StatusRunning
+	if err := m.store.Save(state); err != nil {
+		return fmt.Errorf("saving running state: %w", err)
+	}
+
+	return nil
+}
+
+// Stop gracefully stops an agent.
 func (m *Manager) Stop(name string) error {
 	state, err := m.store.Load(name)
 	if err != nil {
@@ -159,14 +257,25 @@ func (m *Manager) Stop(name string) error {
 	if state.Status != StatusRunning {
 		return fmt.Errorf("agent %q is not running (status: %s)", name, state.Status)
 	}
-	if state.ContainerID == "" {
-		return fmt.Errorf("agent %q has no container ID", name)
-	}
 
-	if err := m.ctr.stopContainer(state.ContainerID); err != nil {
-		state.Status = StatusStopped
-		m.store.Save(state)
-		return fmt.Errorf("stopping agent container: %w", err)
+	if state.Mode == ModeProcess {
+		if state.PID <= 0 {
+			return fmt.Errorf("agent %q has no PID", name)
+		}
+		if err := m.proc.killProcess(state.PID); err != nil {
+			state.Status = StatusStopped
+			m.store.Save(state)
+			return fmt.Errorf("stopping agent process: %w", err)
+		}
+	} else {
+		if state.ContainerID == "" {
+			return fmt.Errorf("agent %q has no container ID", name)
+		}
+		if err := m.ctr.stopContainer(state.ContainerID); err != nil {
+			state.Status = StatusStopped
+			m.store.Save(state)
+			return fmt.Errorf("stopping agent container: %w", err)
+		}
 	}
 
 	state.Status = StatusStopped
@@ -174,21 +283,33 @@ func (m *Manager) Stop(name string) error {
 }
 
 // Restart stops and starts an agent, preserving session for continuity.
-func (m *Manager) Restart(name string, agentCfg config.AgentConfig, cfg *config.Config) error {
+func (m *Manager) Restart(name string, agentCfg config.AgentConfig, cfg *config.Config, opts ...CreateOpts) error {
 	state, err := m.store.Load(name)
 	if err != nil {
 		return err
 	}
 
-	if state.Status == StatusRunning && state.ContainerID != "" {
-		m.ctr.stopContainer(state.ContainerID)
-		m.ctr.rmContainer(state.ContainerID)
+	if state.Status == StatusRunning {
+		if state.Mode == ModeProcess {
+			if state.PID > 0 {
+				m.proc.killProcess(state.PID)
+			}
+		} else if state.ContainerID != "" {
+			m.ctr.stopContainer(state.ContainerID)
+			m.ctr.rmContainer(state.ContainerID)
+		}
 	}
 
 	sessionID := state.SessionID
+	mode := state.Mode
 	m.store.Remove(name)
 
-	if err := m.Create(name, agentCfg, cfg); err != nil {
+	// Preserve mode from previous state if not specified in opts
+	if len(opts) == 0 && mode == ModeProcess {
+		opts = []CreateOpts{{Mode: ModeProcess}}
+	}
+
+	if err := m.Create(name, agentCfg, cfg, opts...); err != nil {
 		return err
 	}
 
@@ -208,9 +329,15 @@ func (m *Manager) Remove(name string) error {
 		return err
 	}
 
-	if state.Status == StatusRunning && state.ContainerID != "" {
-		m.ctr.stopContainer(state.ContainerID)
-		m.ctr.rmContainer(state.ContainerID)
+	if state.Status == StatusRunning {
+		if state.Mode == ModeProcess {
+			if state.PID > 0 {
+				m.proc.killProcess(state.PID)
+			}
+		} else if state.ContainerID != "" {
+			m.ctr.stopContainer(state.ContainerID)
+			m.ctr.rmContainer(state.ContainerID)
+		}
 	}
 
 	return m.store.Remove(name)
@@ -226,32 +353,53 @@ func (m *Manager) Send(name, message string) (string, error) {
 		return "", fmt.Errorf("agent %q is not running (status: %s)", name, state.Status)
 	}
 
-	claudeArgs := []string{"exec"}
-	if state.WorkDir != "" {
-		claudeArgs = append(claudeArgs, "-w", state.WorkDir)
-	}
-	claudeArgs = append(claudeArgs, state.ContainerID,
-		"claude", "--dangerously-skip-permissions", "--output-format", "stream-json", "--verbose")
-	if state.Model != "" {
-		claudeArgs = append(claudeArgs, "--model", state.Model)
-	}
-	if state.SessionID != "" {
-		claudeArgs = append(claudeArgs, "--resume", state.SessionID)
-	} else if state.SystemPrompt != "" {
-		claudeArgs = append(claudeArgs, "--system-prompt", state.SystemPrompt)
-	}
-	claudeArgs = append(claudeArgs, "-p", message)
+	var rawOutput string
 
-	cmd := m.ctr.execFn(m.ctr.runtime, claudeArgs...)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("sending message to agent %q: %s: %w", name, strings.TrimSpace(stderr.String()), err)
+	if state.Mode == ModeProcess {
+		out, err := m.proc.sendMessage(message, state.WorkDir, state.Model, state.SessionID, state.SystemPrompt, nil)
+		if err != nil {
+			return "", fmt.Errorf("sending message to agent %q: %w", name, err)
+		}
+		rawOutput = out
+	} else {
+		claudeArgs := []string{"exec"}
+		if state.WorkDir != "" {
+			claudeArgs = append(claudeArgs, "-w", state.WorkDir)
+		}
+		claudeArgs = append(claudeArgs, state.ContainerID,
+			"claude", "--dangerously-skip-permissions", "--output-format", "stream-json", "--verbose")
+		if state.Model != "" {
+			claudeArgs = append(claudeArgs, "--model", state.Model)
+		}
+		if state.SessionID != "" {
+			claudeArgs = append(claudeArgs, "--resume", state.SessionID)
+		} else if state.SystemPrompt != "" {
+			claudeArgs = append(claudeArgs, "--system-prompt", state.SystemPrompt)
+		}
+		claudeArgs = append(claudeArgs, "-p", message)
+
+		cmd := m.ctr.execFn(m.ctr.runtime, claudeArgs...)
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return "", fmt.Errorf("sending message to agent %q: %s: %w", name, strings.TrimSpace(stderr.String()), err)
+		}
+		rawOutput = stdout.String()
 	}
 
+	resultText := parseStreamJSON(rawOutput, state)
+
+	state.NumTurns++
+	m.store.Save(state)
+
+	return resultText, nil
+}
+
+// parseStreamJSON extracts the result text from stream-json output and captures session ID.
+func parseStreamJSON(output string, state *State) string {
 	var resultText string
-	for _, line := range strings.Split(stdout.String(), "\n") {
+	for _, line := range strings.Split(output, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
@@ -272,19 +420,35 @@ func (m *Manager) Send(name, message string) (string, error) {
 			}
 		}
 	}
-
-	state.NumTurns++
-	m.store.Save(state)
-
-	return resultText, nil
+	return resultText
 }
 
-// RefreshStatus syncs persisted state with actual container status.
+// RefreshStatus syncs persisted state with actual runtime status.
 func (m *Manager) RefreshStatus(name string) (*State, error) {
 	state, err := m.store.Load(name)
 	if err != nil {
 		return nil, err
 	}
+
+	if state.Mode == ModeProcess {
+		if state.PID <= 0 {
+			return state, nil
+		}
+		if m.proc.isProcessRunning(state.PID) {
+			if state.Status != StatusRunning {
+				state.Status = StatusRunning
+				m.store.Save(state)
+			}
+		} else {
+			if state.Status == StatusRunning {
+				state.Status = StatusStopped
+				m.store.Save(state)
+			}
+		}
+		return state, nil
+	}
+
+	// Container mode
 	if state.ContainerID == "" {
 		return state, nil
 	}

--- a/internal/agent/process_ops.go
+++ b/internal/agent/process_ops.go
@@ -1,0 +1,156 @@
+package agent
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// processOps handles low-level process operations for process-mode agents.
+type processOps struct {
+	execFn  ExecFunc
+	homeDir string
+}
+
+// startProcess launches claude as a background process and returns its PID.
+func (p *processOps) startProcess(prompt, logFile, workDir, model, systemPrompt string, env map[string]string) (int, error) {
+	claudeArgs := []string{"--dangerously-skip-permissions", "--output-format", "stream-json", "--verbose"}
+	if model != "" {
+		claudeArgs = append(claudeArgs, "--model", model)
+	}
+	if systemPrompt != "" {
+		claudeArgs = append(claudeArgs, "--system-prompt", systemPrompt)
+	}
+	claudeArgs = append(claudeArgs, "-p", prompt)
+
+	cmd := p.execFn("claude", claudeArgs...)
+	if workDir != "" {
+		cmd.Dir = workDir
+	}
+
+	// Set up env vars
+	if len(env) > 0 {
+		cmd.Env = os.Environ()
+		for k, v := range env {
+			cmd.Env = append(cmd.Env, k+"="+v)
+		}
+	}
+
+	// Redirect output to log file
+	f, err := os.Create(logFile)
+	if err != nil {
+		return 0, fmt.Errorf("creating log file: %w", err)
+	}
+	cmd.Stdout = f
+	cmd.Stderr = f
+
+	// Detach from parent process group so the child survives
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	if err := cmd.Start(); err != nil {
+		f.Close()
+		return 0, fmt.Errorf("starting claude process: %w", err)
+	}
+
+	pid := cmd.Process.Pid
+
+	// Release the process so it runs independently
+	go func() {
+		cmd.Wait()
+		f.Close()
+	}()
+
+	return pid, nil
+}
+
+// sendMessage runs a new claude process with a message and returns the output.
+// For process agents, each send is a separate claude invocation with --resume.
+func (p *processOps) sendMessage(message, workDir, model, sessionID, systemPrompt string, env map[string]string) (string, error) {
+	claudeArgs := []string{"--dangerously-skip-permissions", "--output-format", "stream-json", "--verbose"}
+	if model != "" {
+		claudeArgs = append(claudeArgs, "--model", model)
+	}
+	if sessionID != "" {
+		claudeArgs = append(claudeArgs, "--resume", sessionID)
+	} else if systemPrompt != "" {
+		claudeArgs = append(claudeArgs, "--system-prompt", systemPrompt)
+	}
+	claudeArgs = append(claudeArgs, "-p", message)
+
+	cmd := p.execFn("claude", claudeArgs...)
+	if workDir != "" {
+		cmd.Dir = workDir
+	}
+	if len(env) > 0 {
+		cmd.Env = os.Environ()
+		for k, v := range env {
+			cmd.Env = append(cmd.Env, k+"="+v)
+		}
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("claude process: %s: %w", strings.TrimSpace(stderr.String()), err)
+	}
+
+	return stdout.String(), nil
+}
+
+// killProcess sends SIGTERM to a process by PID.
+func (p *processOps) killProcess(pid int) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("finding process %d: %w", pid, err)
+	}
+	if err := proc.Signal(syscall.SIGTERM); err != nil {
+		return fmt.Errorf("killing process %d: %w", pid, err)
+	}
+	return nil
+}
+
+// isProcessRunning checks if a process with the given PID is alive.
+func (p *processOps) isProcessRunning(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	// Signal 0 checks if process exists without sending a signal
+	err = proc.Signal(syscall.Signal(0))
+	return err == nil
+}
+
+// processStatus returns a human-readable status string for a PID.
+func (p *processOps) processStatus(pid int) string {
+	if pid <= 0 {
+		return "unknown"
+	}
+	// Read /proc/<pid>/stat for process state on Linux
+	data, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/stat")
+	if err != nil {
+		return "exited"
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) < 3 {
+		return "unknown"
+	}
+	switch fields[2] {
+	case "R":
+		return "running"
+	case "S":
+		return "running" // sleeping (waiting for I/O) counts as running
+	case "Z":
+		return "zombie"
+	case "T":
+		return "stopped"
+	default:
+		return "running"
+	}
+}

--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -32,27 +32,61 @@ var agentCreateCmd = &cobra.Command{
 	ValidArgsFunction: agentNameCompletionFunc,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
+		modeStr, _ := cmd.Flags().GetString("mode")
+		prompt, _ := cmd.Flags().GetString("prompt")
+		workDir, _ := cmd.Flags().GetString("work-dir")
 
-		// Try daemon first
-		homeDir, _ := os.UserHomeDir()
-		socketPath := daemon.SocketPath(homeDir)
-		if daemon.IsRunning(socketPath) {
-			resp, err := daemon.Call(socketPath, "create", map[string]string{"name": name})
-			if err != nil {
-				return err
-			}
-			if resp.Error != "" {
-				return fmt.Errorf("%s", resp.Error)
-			}
-			fmt.Printf("Agent %s created (via daemon)\n", name)
-			return nil
+		mode := agent.AgentMode(modeStr)
+		if mode != agent.ModeContainer && mode != agent.ModeProcess {
+			return fmt.Errorf("invalid mode %q: must be 'container' or 'process'", modeStr)
 		}
 
-		// Direct mode (no daemon)
+		// Try daemon first (container mode only)
+		if mode == agent.ModeContainer {
+			homeDir, _ := os.UserHomeDir()
+			socketPath := daemon.SocketPath(homeDir)
+			if daemon.IsRunning(socketPath) {
+				resp, err := daemon.Call(socketPath, "create", map[string]string{"name": name})
+				if err != nil {
+					return err
+				}
+				if resp.Error != "" {
+					return fmt.Errorf("%s", resp.Error)
+				}
+				fmt.Printf("Agent %s created (via daemon)\n", name)
+				return nil
+			}
+		}
+
+		// Direct mode
 		cfg, agentCfg, err := loadAgentConfig(name)
 		if err != nil {
 			return err
 		}
+
+		opts := agent.CreateOpts{
+			Mode:    mode,
+			Prompt:  prompt,
+			WorkDir: workDir,
+		}
+
+		if mode == agent.ModeProcess {
+			// Process mode doesn't need container runtime
+			store, err := defaultAgentStore()
+			if err != nil {
+				return err
+			}
+			homeDir, _ := os.UserHomeDir()
+			mgr := agent.NewManager(store, exec.Command, "", homeDir)
+			if err := mgr.Create(name, agentCfg, cfg, opts); err != nil {
+				return err
+			}
+			state, _ := store.Load(name)
+			fmt.Printf("Agent %s created (process: PID %d)\n", name, state.PID)
+			return nil
+		}
+
+		// Container mode
 		mgr, err := newAgentManager(cfg)
 		if err != nil {
 			return err
@@ -60,7 +94,7 @@ var agentCreateCmd = &cobra.Command{
 		if err := openVaultIfNeeded(mgr, agentCfg); err != nil {
 			return err
 		}
-		if err := mgr.Create(name, agentCfg, cfg); err != nil {
+		if err := mgr.Create(name, agentCfg, cfg, opts); err != nil {
 			return err
 		}
 		store, _ := defaultAgentStore()
@@ -83,11 +117,6 @@ var agentListCmd = &cobra.Command{
 			return err
 		}
 
-		cfg, _, _, err := loadContainerDeps()
-		if err != nil {
-			return err
-		}
-
 		states, err := store.List()
 		if err != nil {
 			return err
@@ -97,23 +126,33 @@ var agentListCmd = &cobra.Command{
 			return nil
 		}
 
-		// Refresh status from container runtime
+		// Detect runtime for container agents (best-effort)
 		homeDir, _ := os.UserHomeDir()
-		runtime, _ := container.DetectRuntime(cfg.ContainerRuntime)
+		var runtime string
+		cfg, _, _, cfgErr := loadContainerDeps()
+		if cfgErr == nil {
+			runtime, _ = container.DetectRuntime(cfg.ContainerRuntime)
+		}
 		mgr := agent.NewManager(store, exec.Command, runtime, homeDir)
 
-		fmt.Printf("%-15s %-12s %-15s %-8s %s\n", "NAME", "STATUS", "CONTAINER", "TURNS", "CREATED")
+		fmt.Printf("%-15s %-10s %-12s %-15s %-8s %s\n", "NAME", "MODE", "STATUS", "ID", "TURNS", "CREATED")
 		for _, s := range states {
 			refreshed, _ := mgr.RefreshStatus(s.Name)
 			if refreshed != nil {
 				s = refreshed
 			}
-			cid := s.ContainerID
-			if len(cid) > 12 {
-				cid = cid[:12]
+			mode := string(s.Mode)
+			if mode == "" {
+				mode = "container"
 			}
-			fmt.Printf("%-15s %-12s %-15s %-8d %s\n",
-				s.Name, s.Status, cid, s.NumTurns, s.CreatedAt.Format("2006-01-02 15:04"))
+			id := s.ContainerID
+			if s.Mode == agent.ModeProcess {
+				id = fmt.Sprintf("PID %d", s.PID)
+			} else if len(id) > 12 {
+				id = id[:12]
+			}
+			fmt.Printf("%-15s %-10s %-12s %-15s %-8d %s\n",
+				s.Name, mode, s.Status, id, s.NumTurns, s.CreatedAt.Format("2006-01-02 15:04"))
 		}
 		return nil
 	},
@@ -148,11 +187,7 @@ var agentSendCmd = &cobra.Command{
 		}
 
 		// Direct mode
-		cfg, _, err := loadAgentConfig(name)
-		if err != nil {
-			return err
-		}
-		mgr, err := newAgentManager(cfg)
+		mgr, err := newAgentManagerForExisting(name)
 		if err != nil {
 			return err
 		}
@@ -211,11 +246,7 @@ var agentStopCmd = &cobra.Command{
 		}
 
 		// Direct mode
-		cfg, _, err := loadAgentConfig(name)
-		if err != nil {
-			return err
-		}
-		mgr, err := newAgentManager(cfg)
+		mgr, err := newAgentManagerForExisting(name)
 		if err != nil {
 			return err
 		}
@@ -258,11 +289,7 @@ var agentRmCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
-		cfg, _, err := loadAgentConfig(name)
-		if err != nil {
-			return err
-		}
-		mgr, err := newAgentManager(cfg)
+		mgr, err := newAgentManagerForExisting(name)
 		if err != nil {
 			return err
 		}
@@ -344,6 +371,10 @@ var agentChatCmd = &cobra.Command{
 }
 
 func init() {
+	agentCreateCmd.Flags().String("mode", "container", "Agent mode: 'container' or 'process'")
+	agentCreateCmd.Flags().String("prompt", "", "Initial prompt for process-mode agents")
+	agentCreateCmd.Flags().String("work-dir", "", "Override work directory (process mode)")
+
 	agentLogsCmd.Flags().BoolP("follow", "f", false, "Follow log output")
 	agentLogsCmd.Flags().Bool("raw", false, "Show raw NDJSON instead of formatted output")
 
@@ -436,6 +467,36 @@ func openVaultIfNeeded(mgr *agent.Manager, agentCfg config.AgentConfig) error {
 
 	mgr.Vault = v
 	return nil
+}
+
+// newAgentManagerForExisting creates an agent.Manager appropriate for an already-created agent.
+// For process-mode agents, no container runtime is needed.
+func newAgentManagerForExisting(name string) (*agent.Manager, error) {
+	store, err := defaultAgentStore()
+	if err != nil {
+		return nil, err
+	}
+	state, err := store.Load(name)
+	if err != nil {
+		return nil, err
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	if state.Mode == agent.ModeProcess {
+		return agent.NewManager(store, exec.Command, "", homeDir), nil
+	}
+	// Container mode — need runtime
+	cfg, _, err := loadAgentConfig(name)
+	if err != nil {
+		return nil, err
+	}
+	runtime, err := container.DetectRuntime(cfg.ContainerRuntime)
+	if err != nil {
+		return nil, err
+	}
+	return agent.NewManager(store, exec.Command, runtime, homeDir), nil
 }
 
 // agentNameCompletionFunc provides shell completion for agent names.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -21,9 +21,9 @@ import (
 
 // agentManager abstracts agent lifecycle operations.
 type agentManager interface {
-	Create(name string, agentCfg config.AgentConfig, cfg *config.Config) error
+	Create(name string, agentCfg config.AgentConfig, cfg *config.Config, opts ...agent.CreateOpts) error
 	Stop(name string) error
-	Restart(name string, agentCfg config.AgentConfig, cfg *config.Config) error
+	Restart(name string, agentCfg config.AgentConfig, cfg *config.Config, opts ...agent.CreateOpts) error
 	Remove(name string) error
 	Send(name, message string) (string, error)
 	RefreshStatus(name string) (*agent.State, error)


### PR DESCRIPTION
## Summary
- Adds `--mode process` flag to `myhome agent create` for spawning Claude CLI as background processes
- Enables recursive agent spawning inside containers without Docker-in-Docker
- Process agents managed via PID tracking, with send/list/rm support

## Changes
- `internal/agent/agent.go`: Add Mode field, CreateOpts, process-mode create/send/list/rm logic
- `internal/agent/process_ops.go`: New file for process lifecycle (start, send, kill, status)
- `internal/cmd/agent.go`: Add `--mode` flag to CLI
- `internal/daemon/daemon.go`: Update interface for new Create/Restart signatures

## Test plan
- [ ] `myhome agent create test --mode process --prompt "say hi"` spawns background process
- [ ] `myhome agent list` shows process agent with PID
- [ ] `myhome agent send test "hello"` returns response
- [ ] `myhome agent rm test` kills process
- [ ] Existing container-mode agents still work unchanged

Implements #44

🤖 Generated with Claude Code by Kira agent running inside myhome container