### PR TITLE
feat: add --max-turns flag and agent stats tracking

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -216,8 +216,13 @@ func (m *Manager) Remove(name string) error {
 	return m.store.Remove(name)
 }
 
+// SendOptions holds optional parameters for Send.
+type SendOptions struct {
+	MaxTurns int // passed through to Claude CLI --max-turns
+}
+
 // Send sends a message to a running agent and returns the response.
-func (m *Manager) Send(name, message string) (string, error) {
+func (m *Manager) Send(name, message string, opts *SendOptions) (string, error) {
 	state, err := m.store.Load(name)
 	if err != nil {
 		return "", err
@@ -234,6 +239,9 @@ func (m *Manager) Send(name, message string) (string, error) {
 		"claude", "--dangerously-skip-permissions", "--output-format", "stream-json", "--verbose")
 	if state.Model != "" {
 		claudeArgs = append(claudeArgs, "--model", state.Model)
+	}
+	if opts != nil && opts.MaxTurns > 0 {
+		claudeArgs = append(claudeArgs, "--max-turns", fmt.Sprintf("%d", opts.MaxTurns))
 	}
 	if state.SessionID != "" {
 		claudeArgs = append(claudeArgs, "--resume", state.SessionID)
@@ -269,6 +277,9 @@ func (m *Manager) Send(name, message string) (string, error) {
 		if msgType == "result" {
 			if r, ok := msg["result"].(string); ok {
 				resultText = r
+			}
+			if cost, ok := msg["total_cost_usd"].(float64); ok {
+				state.TotalCostUSD += cost
 			}
 		}
 	}

--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -102,7 +102,7 @@ var agentListCmd = &cobra.Command{
 		runtime, _ := container.DetectRuntime(cfg.ContainerRuntime)
 		mgr := agent.NewManager(store, exec.Command, runtime, homeDir)
 
-		fmt.Printf("%-15s %-12s %-15s %-8s %s\n", "NAME", "STATUS", "CONTAINER", "TURNS", "CREATED")
+		fmt.Printf("%-15s %-12s %-15s %-8s %-10s %s\n", "NAME", "STATUS", "CONTAINER", "TURNS", "COST", "CREATED")
 		for _, s := range states {
 			refreshed, _ := mgr.RefreshStatus(s.Name)
 			if refreshed != nil {
@@ -112,8 +112,9 @@ var agentListCmd = &cobra.Command{
 			if len(cid) > 12 {
 				cid = cid[:12]
 			}
-			fmt.Printf("%-15s %-12s %-15s %-8d %s\n",
-				s.Name, s.Status, cid, s.NumTurns, s.CreatedAt.Format("2006-01-02 15:04"))
+			cost := fmt.Sprintf("$%.2f", s.TotalCostUSD)
+			fmt.Printf("%-15s %-12s %-15s %-8d %-10s %s\n",
+				s.Name, s.Status, cid, s.NumTurns, cost, s.CreatedAt.Format("2006-01-02 15:04"))
 		}
 		return nil
 	},
@@ -126,15 +127,27 @@ var agentSendCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
 		message := args[1]
+		maxTurns, _ := cmd.Flags().GetInt("max-turns")
+
+		// If no flag, check agent config default
+		if maxTurns == 0 {
+			if _, agentCfg, err := loadAgentConfig(name); err == nil {
+				maxTurns = agentCfg.MaxTurns
+			}
+		}
 
 		// Try daemon first
 		homeDir, _ := os.UserHomeDir()
 		socketPath := daemon.SocketPath(homeDir)
 		if daemon.IsRunning(socketPath) {
-			resp, err := daemon.Call(socketPath, "send", map[string]string{
+			params := map[string]any{
 				"name":    name,
 				"message": message,
-			})
+			}
+			if maxTurns > 0 {
+				params["max_turns"] = maxTurns
+			}
+			resp, err := daemon.Call(socketPath, "send", params)
 			if err != nil {
 				return err
 			}
@@ -156,7 +169,11 @@ var agentSendCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		response, err := mgr.Send(name, message)
+		var opts *agent.SendOptions
+		if maxTurns > 0 {
+			opts = &agent.SendOptions{MaxTurns: maxTurns}
+		}
+		response, err := mgr.Send(name, message, opts)
 		if err != nil {
 			return err
 		}
@@ -331,7 +348,7 @@ var agentChatCmd = &cobra.Command{
 				}
 				json.Unmarshal(resp.Result, &response)
 			} else {
-				r, err := mgr.Send(name, line)
+				r, err := mgr.Send(name, line, nil)
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 					continue
@@ -343,9 +360,42 @@ var agentChatCmd = &cobra.Command{
 	},
 }
 
+var agentStatsCmd = &cobra.Command{
+	Use:               "stats <name>",
+	Short:             "Show agent resource usage (turns, cost)",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: agentNameCompletionFunc,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := args[0]
+		store, err := defaultAgentStore()
+		if err != nil {
+			return err
+		}
+		state, err := store.Load(name)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Agent:      %s\n", state.Name)
+		fmt.Printf("Status:     %s\n", state.Status)
+		fmt.Printf("Turns:      %d\n", state.NumTurns)
+		fmt.Printf("Total cost: $%.4f\n", state.TotalCostUSD)
+		fmt.Printf("Created:    %s\n", state.CreatedAt.Format("2006-01-02 15:04:05"))
+		if state.Model != "" {
+			fmt.Printf("Model:      %s\n", state.Model)
+		}
+		if state.SessionID != "" {
+			fmt.Printf("Session:    %s\n", state.SessionID)
+		}
+		return nil
+	},
+}
+
 func init() {
 	agentLogsCmd.Flags().BoolP("follow", "f", false, "Follow log output")
 	agentLogsCmd.Flags().Bool("raw", false, "Show raw NDJSON instead of formatted output")
+
+	agentSendCmd.Flags().Int("max-turns", 0, "Maximum agentic turns for this message (0 = unlimited)")
 
 	agentCmd.AddCommand(agentCreateCmd)
 	agentCmd.AddCommand(agentListCmd)
@@ -355,6 +405,7 @@ func init() {
 	agentCmd.AddCommand(agentStopCmd)
 	agentCmd.AddCommand(agentRestartCmd)
 	agentCmd.AddCommand(agentRmCmd)
+	agentCmd.AddCommand(agentStatsCmd)
 }
 
 // loadAgentConfig loads the full config and the named agent's config.

--- a/internal/config/agent.go
+++ b/internal/config/agent.go
@@ -8,6 +8,7 @@ type AgentConfig struct {
 	SystemPrompt string            `yaml:"system_prompt,omitempty"`
 	AllowedTools []string          `yaml:"allowed_tools,omitempty"`
 	MaxBudgetUSD float64           `yaml:"max_budget_usd,omitempty"`
+	MaxTurns     int               `yaml:"max_turns,omitempty"`
 	Identity     AgentIdentity     `yaml:"identity,omitempty"`
 	Secrets      AgentSecrets      `yaml:"secrets,omitempty"`
 	Env          map[string]string `yaml:"env,omitempty"`

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -25,7 +25,7 @@ type agentManager interface {
 	Stop(name string) error
 	Restart(name string, agentCfg config.AgentConfig, cfg *config.Config) error
 	Remove(name string) error
-	Send(name, message string) (string, error)
+	Send(name, message string, opts *agent.SendOptions) (string, error)
 	RefreshStatus(name string) (*agent.State, error)
 }
 

--- a/internal/daemon/handlers.go
+++ b/internal/daemon/handlers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/kgatilin/myhome/internal/agent"
 	"github.com/kgatilin/myhome/internal/config"
 )
 
@@ -12,8 +13,9 @@ type nameParam struct {
 }
 
 type sendParam struct {
-	Name    string `json:"name"`
-	Message string `json:"message"`
+	Name     string `json:"name"`
+	Message  string `json:"message"`
+	MaxTurns int    `json:"max_turns,omitempty"`
 }
 
 // handler processes daemon RPC requests using the manager and store.
@@ -57,7 +59,11 @@ func (h *handler) handleSend(params json.RawMessage) Response {
 	if err := json.Unmarshal(params, &p); err != nil {
 		return Response{Error: fmt.Sprintf("invalid params: %v", err)}
 	}
-	response, err := h.manager.Send(p.Name, p.Message)
+	var opts *agent.SendOptions
+	if p.MaxTurns > 0 {
+		opts = &agent.SendOptions{MaxTurns: p.MaxTurns}
+	}
+	response, err := h.manager.Send(p.Name, p.Message, opts)
 	if err != nil {
 		return Response{Error: err.Error()}
 	}


### PR DESCRIPTION
## Summary
- Add `--max-turns` flag to `myhome agent send` — controls how many iterations Claude CLI can run
- Add `defaults.max_turns` in agent config (myhome.yml) for per-agent defaults
- Parse `total_cost_usd` from Claude CLI stream-json output after each send
- Accumulate cost and turns in agent state
- New `myhome agent stats <name>` subcommand showing usage summary

## Changes
- `internal/cmd/agent.go`: Add --max-turns flag and stats subcommand
- `internal/agent/agent.go`: Cost tracking, stats collection
- `internal/config/agent.go`: Add Defaults.MaxTurns to config schema
- `internal/daemon/`: Update interfaces

## Test plan
- [ ] `myhome agent send kira "hi" --max-turns 5` limits iterations
- [ ] Config `defaults.max_turns` used when flag not provided
- [ ] `myhome agent stats kira` shows accumulated turns and cost
- [ ] Existing agents without defaults still work

Implements #46

🤖 Generated by Kira agent in myhome container