### PR TITLE
docs: add deskd integration guide and architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,62 @@
 A Go CLI tool that manages a git-tracked home folder across multiple machines and environments.
 See `docs/init.md` for full scope and requirements, `docs/implementation-plan.md` for the build plan.
 
+## System Architecture: myhome + deskd
+
+myhome is the **workspace manager** — it handles machine setup, repos, tools, containers, auth.
+Agent orchestration is handled by a separate Rust project: **[deskd](https://github.com/kira-autonoma/deskd)**.
+
+```
+myhome (Go) — workspace                deskd (Rust) — agent runtime
+├── repos, tools, packages             ├── agent lifecycle (create/send/list/rm)
+├── containers (build, Dockerfile)      ├── prompt routing (promptlint)
+├── auth profiles, SSH, git identity    ├── context pool + forks + queues
+├── remote VPS management               ├── cost tracking + budgets
+├── myhome init --env work              ├── task API (HTTP)
+└── calls deskd for agent ops          └── session resume, stream-json parsing
+```
+
+### Data Access Model
+
+Each agent has a **Desk** (scoped data access):
+- **Physical data**: filesystem mounts, API tokens, credentials — ONLY own desk
+- **Shared data**: `/shared/` — all agents read, only owner writes
+- **Context**: own context RW, other agents' context via publish/subscribe/query
+- **Credentials**: NEVER shared between agents
+
+```
+agents:
+  dev:     desk=~/work/   creds=GitHub,GitLab  tools=Claude,MCP,archlint
+  school:  desk=Gmail     creds=Google OAuth    tools=email,Telegram
+  analyst: desk=web       creds=—               tools=search,Playwright
+```
+
+Context sharing between agents uses event queues:
+- Agent publishes discoveries (visibility: all/specific/none)
+- Other agents subscribe to event types (schedule, warnings, decisions)
+- Queries: agent can request context from another, owner decides to share or deny
+
+### Related Projects
+
+| Project | Language | Role |
+|---------|----------|------|
+| [myhome](https://github.com/kgatilin/myhome) | Go | Workspace manager |
+| [deskd](https://github.com/kira-autonoma/deskd) | Rust | Agent orchestration runtime |
+| [promptlint](https://github.com/mikeshogin/promptlint) | Go | Prompt complexity analysis + routing |
+| [archlint](https://github.com/mshogin/archlint) | Go | Architecture quality validation |
+
+### Key Issues Tracking Agent Architecture
+
+- [#44](https://github.com/kgatilin/myhome/issues/44) — Process-mode sub-agents (PR #45)
+- [#46](https://github.com/kgatilin/myhome/issues/46) — --max-turns + cost tracking (PR #47)
+- [#48](https://github.com/kgatilin/myhome/issues/48) — Hook/Plugin API (pre-route, post-validate)
+- [#49](https://github.com/kgatilin/myhome/issues/49) — Prompt routing via promptlint
+- [#50](https://github.com/kgatilin/myhome/issues/50) — Quality gate stage in workflows
+- [#51](https://github.com/kgatilin/myhome/issues/51) — Cost tracking (costlint)
+- [#52](https://github.com/kgatilin/myhome/issues/52) — Task creation HTTP API
+- [#53](https://github.com/kgatilin/myhome/issues/53) — Context management + forks + queues
+- [#55](https://github.com/kgatilin/myhome/issues/55) — TON Jetton tokens for agent economy
+
 ## Implementation
 
 Follow `docs/implementation-plan.md` strictly — implement iteration by iteration, mark tasks as done.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,12 @@ Run `archlint collect . -l go -o architecture.yaml` to generate a full architect
 - Container configs in myhome.yml must include `startup_commands` with a `{{.Prompt}}` template variable. The task runner renders this but does not add its own command. Example: `"exec claude --dangerously-skip-permissions --output-format text -p {{.Prompt}}"`
 - `dependencies_go.txt` supports a `source:` prefix for packages that can't be `go install`ed (e.g. module path mismatches). Format: `source:github.com/user/repo cmd/tool` — triggers git clone + go build instead of go install. Use `go_deps_file:` in container config to install at build time (required for firewalled containers).
 
+### Agent Runtime (deskd)
+
+Agent orchestration is handled by a separate Rust project: [deskd](https://github.com/kira-autonoma/deskd).
+myhome manages workspace (repos, tools, auth), deskd manages agents (lifecycle, routing, context, cost).
+See `docs/deskd-integration.md` for full architecture, domain model, and data access patterns.
+
 ### Dependencies
 
 - `github.com/spf13/cobra` — CLI framework

--- a/docs/deskd-integration.md
+++ b/docs/deskd-integration.md
@@ -1,0 +1,120 @@
+# deskd — Agent Runtime (Rust)
+
+## What is deskd
+
+A separate Rust project that handles agent orchestration: spawning, routing, context management, and cost tracking. myhome manages the workspace (repos, tools, auth), deskd manages the agents.
+
+**Repo**: https://github.com/kira-autonoma/deskd
+
+## Architecture Split
+
+```
+myhome (Go) — workspace manager        deskd (Rust) — agent runtime
+├── Repos (clone, sync, worktrees)      ├── Agent lifecycle (create/send/list/rm)
+├── Tools (mise, go, node, python)      ├── Prompt routing (promptlint)
+├── Packages (brew, apt)                ├── Context pool + forks + queues
+├── Auth (SSH, git identity)            ├── Cost tracking + budgets
+├── Containers (build, run)             ├── Task API (HTTP/gRPC)
+├── Vault (KeePassXC)                   └── Economy (TON payments, future)
+├── Remote (SSH + tmux)
+└── Schedule (cron tasks)
+```
+
+myhome calls deskd for agent operations. deskd doesn't know about repos or packages.
+
+## How They Work Together
+
+```bash
+myhome init --env work          # sets up machine: repos, tools, packages, auth
+myhome container build claude   # builds Docker image
+
+deskd agent create dev \        # creates agent with scoped access
+  --workdir ~/work/uagent \
+  --model claude-sonnet-4-20250514
+
+deskd agent send dev "fix the auth bug"   # agent works, cost tracked
+deskd agent stats dev                      # shows turns, cost, session info
+```
+
+## Domain Model
+
+### Agents (top-level, life/work domains)
+
+| Agent   | Scope                      | What it does                            |
+|---------|----------------------------|-----------------------------------------|
+| dev     | repos, CI/CD, code         | Software development                    |
+| school  | Gmail, Telegram channel    | School notifications + follow-ups       |
+| analyst | web access, Playwright     | Research, comparisons, price tracking   |
+| manager | calendar, tasks, people    | Coordination, reminders, collaboration  |
+| home    | booking sites, monitoring  | Reservations, monitoring                |
+| collab  | shared repos, channels     | Shared work with collaborators          |
+
+### Data Access Model
+
+```
+Filesystem:
+  /shared/              ← all agents read (preferences, contacts, calendar)
+  /desks/dev/           ← only dev agent
+  /desks/school/        ← only school agent
+  /desks/home/          ← only home agent
+
+Context:
+  /context/dev/         ← dev agent's discoveries, decisions
+  /context/school/      ← school agent's knowledge
+  /context/shared/      ← cross-agent facts ("family travels to Karlsruhe on Easter")
+```
+
+**Access rules:**
+1. Physical data (files, APIs): ONLY own desk
+2. /shared/: all read, only owner writes
+3. Own context: full RW
+4. Other agent's context: only if published or answered a query
+5. Credentials: NEVER shared between agents
+6. Urgent events: bypass — all agents receive
+
+### Context Queue (event-driven coordination)
+
+```
+Agent A: "found JWT bug in auth module" → publishes to queue
+Agent B: subscribed to Agent A → receives update → knows about JWT
+
+No direct agent-to-agent calls. Loose coupling via events.
+```
+
+### Prompt Routing (promptlint integration)
+
+```
+Request arrives → promptlint analyze → complexity?
+  ├── high → Claude Opus subprocess (subscription)
+  ├── medium → Claude Sonnet subprocess
+  ├── low → Gemini Flash / cheap model (API key)
+  └── trivial → template response, no LLM
+```
+
+No API proxying — routes to different subprocesses. Each subprocess manages its own auth.
+
+## Related Issues
+
+| Issue | What |
+|-------|------|
+| [#44](https://github.com/kgatilin/myhome/issues/44) | Process-mode sub-agents |
+| [#46](https://github.com/kgatilin/myhome/issues/46) | --max-turns + cost tracking |
+| [#48](https://github.com/kgatilin/myhome/issues/48) | Hook/plugin API |
+| [#49](https://github.com/kgatilin/myhome/issues/49) | Prompt routing |
+| [#50](https://github.com/kgatilin/myhome/issues/50) | Quality gates |
+| [#51](https://github.com/kgatilin/myhome/issues/51) | Cost tracking (costlint) |
+| [#52](https://github.com/kgatilin/myhome/issues/52) | Task creation API |
+| [#53](https://github.com/kgatilin/myhome/issues/53) | Context management |
+| [#55](https://github.com/kgatilin/myhome/issues/55) | TON agent economy |
+
+## deskd CLI Reference
+
+```bash
+deskd agent create <name> [--prompt "..."] [--model ...] [--workdir ...] [--max-turns N]
+deskd agent send <name> "message" [--max-turns N]
+deskd agent list
+deskd agent stats <name>
+deskd agent rm <name>
+```
+
+State stored in `~/.deskd/agents/*.yaml`. Cost and session tracked per agent.


### PR DESCRIPTION
Adds docs/deskd-integration.md with full architecture split (myhome=workspace, deskd=agents), domain model, data access patterns, prompt routing, and related issues index. Reference added to CLAUDE.md.